### PR TITLE
Check alternate config file for install locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 You'll need to make sure you've got these few things set up in order to compile and run SFMF.
 
 - Superflight (installed through Steam)
-- [.NET 4.6.1 developer pack](https://dotnet.microsoft.com/en-us/download/dotnet-framework/thank-you/net461-developer-pack-offline-installer) (I haven't tested which other versions are compatible)
+- [.NET 4.6.1 developer pack](https://dotnet.microsoft.com/en-us/download/dotnet-framework/net461) (I haven't tested which other versions are compatible)
 - Visual Studio
 
 ### Installing

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 You'll need to make sure you've got these few things set up in order to compile and run SFMF.
 
-- Superflight
+- Superflight (installed through Steam)
+- [.NET 4.6.1 developer pack](https://dotnet.microsoft.com/en-us/download/dotnet-framework/thank-you/net461-developer-pack-offline-installer) (I haven't tested which other versions are compatible)
 - Visual Studio
-- .NET 4.6.1 (I haven't tested which other versions are compatible)
 
 ### Installing
 


### PR DESCRIPTION
When I clicked the "Install SFMF" button, the Launcher window closed and the `error.log` file showed this error: 
```
Could not find a part of the path 'C:\superflight_Data\Managed'.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileSystemEnumerableIterator`1.CommonInit()
   at System.IO.FileSystemEnumerableIterator`1..ctor(String path, String originalUserPath, String searchPattern, SearchOption searchOption, SearchResultHandler`1 resultHandler, Boolean checkHost)
   at System.IO.Directory.GetFiles(String path)
   at SFMFManager.Injection.Injector.InstallFramework(Boolean disableScoreReporting) in C:\Users\vic\Documents\projects\desktop\SFMF\SFMFManager\Injection\Injector.cs:line 28
   ...
```

I found that my Steam install directories were not defined in the `config/config.vdf` file as expected, but rather they were defined in the nearby `config/libraryfolders.vdf`.

I'm not totally sure why, but it may be because I have more than one Steam install directory configured:
<img width="638" alt="image" src="https://github.com/vicjohnson1213/SFMF/assets/21367650/02aecf16-eedf-4647-9b23-22304fae3a78">

Anyway, reading install locations from this other file solves the described issue and the rest of the app functions as expected. Please let me know what you think.