### PR TITLE
Added QuickSave

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -162,6 +162,29 @@
 					{ "name": "Color", "value": "#FF0000" }
 				]
 			}
+		},
+		{
+		  "name": "QuickSave",
+		  "homepage": "https://github.com/abadaba42/QuickSave-superflight",
+		  "description": "Create a single quick save at a point to practice tough tricks.",
+		  "authors": ["abadaba42"],
+		  "Version": "v1.0.0",
+		  "download": "https://github.com/abadaba42/QuickSave-superflight/blob/main/bin/Debug/QuickSave.dll",
+		  "disableScoreReporting": true,
+		  "settings": {
+			"Controls": [
+			  {
+				"Action": "Create",
+				"Keyboard": "P",
+				"Controller": "RB"
+			  },
+			  {
+				"Action": "Remove",
+				"Keyboard": "K",
+				"Controller": "R3"
+			  }
+			]
+		  }
 		}
 	]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -169,7 +169,7 @@
 		  "description": "Create a single quick save at a point to practice tough tricks.",
 		  "authors": ["abadaba42"],
 		  "Version": "v1.0.0",
-		  "download": "https://github.com/abadaba42/QuickSave-superflight/blob/main/bin/Debug/QuickSave.dll",
+		  "download": "https://github.com/abadaba42/QuickSave-superflight/releases/download/v1.0.0/QuickSave.dll",
 		  "disableScoreReporting": true,
 		  "settings": {
 			"Controls": [


### PR DESCRIPTION
I've created a basic quicksave mod that allows the creation of a save point so you don't have to fly around to get to a trick spot. 

Feel free to inspect the code out at https://github.com/abadaba42/QuickSave-superflight.

I don't know how to build SFMF myself so am unsure if this all works when the manifest is compiled, but the mod works well when loaded in locally (settings also work with a modified manifest). I've mostly followed your lead and made my mod as similar as possible to your existing code. 

Let me know if there are any changes that need to be made!
Thanks!
